### PR TITLE
Make blog list items title inline with date

### DIFF
--- a/src/_includes/partials/components/post-list.njk
+++ b/src/_includes/partials/components/post-list.njk
@@ -6,12 +6,10 @@
         {% for item in postListItems %}
           {% if item.date.getTime() <= global.now %}
             <li class="post-list__item">
-              <h3 class="font-base leading-tight text-600 weight-mid">
+              <h3 class="font-base leading-tight text-500 weight-mid">
+                <time datetime="{{ item.date | w3DateFilter }}">{{ item.date | dateFilter }}</time> - 
                 <a href="{{ item.url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
               </h3>
-              <p class="text-400 gap-top-300 weight-mid">
-                <time datetime="{{ item.date | w3DateFilter }}">{{ item.date | dateFilter }}</time>
-              </p>
             </li>
           {% endif %}
         {% endfor %}

--- a/src/filters/date-filter.js
+++ b/src/filters/date-filter.js
@@ -10,7 +10,10 @@ module.exports = function dateFilter(value) {
 
   const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
   const dayWithSuffix = appendSuffix(dateObject.getDate());
+  
+  // custom style
+  const customMonths = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
   const dayWithoutSuffix = dateObject.getDate();
 
-  return `${dayWithoutSuffix} ${months[dateObject.getMonth()]} ${dateObject.getFullYear()}`;
+  return `${dayWithoutSuffix} ${customMonths[dateObject.getMonth()]} ${dateObject.getFullYear()}`;
 };


### PR DESCRIPTION
## Description

Change blog list items style, by making post date inline with title, making the list more readable and less sparse.

Fixes #41 

## Before

![date below the title](https://user-images.githubusercontent.com/11148726/97627278-0d0c0080-1a23-11eb-8b21-39dab47a5d44.png)
 
## After

![date inline with title](https://user-images.githubusercontent.com/11148726/97627331-23b25780-1a23-11eb-8959-9e11ee451104.png)
