### PR TITLE
blog: reverse order of tags posts

### DIFF
--- a/src/tags.njk
+++ b/src/tags.njk
@@ -24,7 +24,7 @@ permalink: /tags/{{ tag }}/
 {# Post list content #}
 {% set postListHeadingLevel = '2' %}
 {% set postListHeading = 'Posts' %}
-{% set postListItems = collections[tag] %}
+{% set postListItems = collections[tag] | reverse %}
 
 {% block content %}
   <main id="main-content" tabindex="-1">


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Order tags' posts from most recent to oldest.

Fixes #10

### Why

<!-- Explain why this change was made -->

Because the rest of my website is ordered this way

### User interface

<!-- Include screenshots before and after images-->

| Before | After |
|-|-|
| ![tags's post ordered from oldest to most recent](https://user-images.githubusercontent.com/11148726/110251313-d49fa480-7f77-11eb-9306-90161d373f9e.png) | ![tags's post ordered from most recent to oldest](https://user-images.githubusercontent.com/11148726/110251300-c81b4c00-7f77-11eb-9543-00445f39e790.png) |

### References

<!-- Link inspiration links and references -->

This helped me: https://www.11ty.dev/docs/collections/#sort-descending