### PR TITLE
Posts: Special pages that act like notes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -43,10 +43,18 @@ module.exports = function(config) {
   // Custom collections
 
   // All posts
-  const livePosts = post => post.date <= now && !post.data.draft;
+  const livePosts = post => post.date <= now && !post.data.draft && !post.data.note;
   config.addCollection('posts', collection => {
     return [
       ...collection.getFilteredByGlob('./src/posts/*.md').filter(livePosts)
+    ].reverse();
+  });
+
+  // Notes collections
+  const isNotes = post => post.data.note
+  config.addCollection('notes', collection => {
+    return [
+      ...collection.getFilteredByGlob('./src/posts/*.md').filter(isNotes)
     ].reverse();
   });
 

--- a/src/_includes/layouts/archive.njk
+++ b/src/_includes/layouts/archive.njk
@@ -8,10 +8,15 @@
 {% set postListHeading = 'All posts' %}
 {% set postListItems = collections.posts %}
 
+{# Notes list content #}
+{% set notesListHeading = 'All notes' %}
+{% set notesListItems = collections.notes %}
+
 {% block content %}
   <main id="main-content" tabindex="-1">
     {% include "partials/components/intro.njk" %}
     {% include "partials/components/tags-list.njk" %}
     {% include "partials/components/post-list.njk" %}
+    {% include "partials/components/notes-list.njk" %}
   </main>
 {% endblock %}

--- a/src/_includes/partials/components/notes-list.njk
+++ b/src/_includes/partials/components/notes-list.njk
@@ -1,0 +1,18 @@
+{% if notesListItems.length %}
+  <section class="[ post-list ] [ pad-top-700 gap-bottom-900 ]">
+    <div class="[ inner-wrapper ] [ sf-flow ]">
+      <h2 class="[ post-list__heading ] [ text-700 md:text-800 ]">{{ notesListHeading }}</h2>
+      <ol class="[ post-list__items ] [ sf-flow ] [ pad-top-300 ]" reversed>
+        {% for item in notesListItems %}
+          {% if item.date.getTime() <= global.now %}
+            <li class="post-list__item">
+              <h3 class="font-base leading-tight text-500 weight-mid">
+                <a href="{{ item.url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
+              </h3>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </div>
+  </section>
+{% endif %}

--- a/src/posts/podcasts-i-enjoy.md
+++ b/src/posts/podcasts-i-enjoy.md
@@ -1,13 +1,14 @@
 ---
 title: 🎧 Podcasts I listen to
 date: '2020-07-25'
+note: true
 tags:
   - misc
 ---
 
 I usually listen to podcasts on Spotify. These are some of the podcasts I follow and listen to, more on the tech industry spectrum, whether discussing latest trends in tech industry or experiences in it.
 
-- [Techish podcast](http://www.techishpod.com/)
+- [Techish podcast](http://www.techishpod.com/) - I love this one
 - [Git Cute podcast](https://gitcutepodcast.com/)
 - [Coding Black Females podcast](https://codingblackfemales.com/podcast)
 - [Ladybug podcast](https://ladybug.dev)

--- a/src/posts/podcasts-i-enjoy.md
+++ b/src/posts/podcasts-i-enjoy.md
@@ -1,6 +1,7 @@
 ---
 title: 🎧 Podcasts I listen to
 date: '2020-07-25'
+last_update: '2021-04-30'
 note: true
 tags:
   - misc

--- a/src/posts/talks-i-really-like.md
+++ b/src/posts/talks-i-really-like.md
@@ -1,0 +1,14 @@
+---
+title: 👩🏾‍🏫 Talks I really like
+date: '2021-04-30'
+note: true
+tags:
+  - misc
+---
+
+I love these talks, resonate with me a lot:
+
+- [The Operating System of You](https://www.youtube.com/watch?v=D-Sj6jo4o1I) by Swyx
+- [How to be an Android Expert](https://www.youtube.com/watch?v=IMSY1uH4nT8) by Chiu-ki Chan
+- [Technical leadership and glue work](https://www.youtube.com/watch?v=KClAPipnKqw) by Tanya Reilly
+- [Scaling Yourself](https://www.youtube.com/watch?v=V4NJo2Mfvrc) by Scott Hanselman

--- a/src/posts/talks-i-really-like.md
+++ b/src/posts/talks-i-really-like.md
@@ -1,6 +1,7 @@
 ---
 title: 👩🏾‍🏫 Talks I really like
 date: '2021-04-30'
+last_update: '2021-04-30'
 note: true
 tags:
   - misc


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Added 2 special pages as notes, for podcasts I listen and talks I love.

Fixes #45

### Why

<!-- Explain why this change was made -->

This is the first try at having posts that do not focus on when they were written but instead their content which may change from time to time. E.g.: podcasts I listen to and talks I love and made an impact on me.

### User interface

<!-- Include screenshots before and after images-->

![all notes listed](https://user-images.githubusercontent.com/11148726/116750229-08d49600-a9fa-11eb-9242-7b17d3a0148a.png)

### References

<!-- Link inspiration links and references -->
- https://joelhooks.com/digital-garden