### PR TITLE
Posts: Make links not squared and blue bgd

### DIFF
--- a/src/scss/components/_post.scss
+++ b/src/scss/components/_post.scss
@@ -18,16 +18,28 @@
       @include apply-utility('leading', 'tight');
     }
 
-    a:not([class]) {
-      color: var(--color-dark);
-      position: relative;
-      display: inline-block;
-      background: var(--color-theme-highlight);
-      padding: 0.2rem 0.4rem 0.3rem 0.4rem;
-      text-decoration: none;
-      word-break: break-word;
+    // -----------------------
+    // blue squared link style
+    // -----------------------
 
-      @include apply-utility('leading', 'tight');
+    // a:not([class]) {
+    //   color: var(--color-dark);
+    //   position: relative;
+    //   display: inline-block;
+    //   background: var(--color-theme-highlight);
+    //   padding: 0.2rem 0.4rem 0.3rem 0.4rem;
+    //   text-decoration: none;
+    //   word-break: break-word;
+
+    //   @include apply-utility('leading', 'tight');
+    // }
+
+    a {
+      color: currentColor;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
 
     a:not([class]):hover {


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
Change links SASS to be more toned down. Instead of being inside a blue square, it is only underlined.

### Why

<!-- Explain why this change was made -->
Because it seems out of place in my posts. Personal choice.

### User interface

<!-- Include screenshots before and after images-->

| Before | After |
|-|-|
| ![links with blue squared](https://user-images.githubusercontent.com/11148726/116759527-71c40a00-aa0a-11eb-8d16-53718eeb8eef.png) | ![links only underlined](https://user-images.githubusercontent.com/11148726/116759536-7983ae80-aa0a-11eb-86a9-a787231e8797.png) |

### References

<!-- Link inspiration links and references -->
- N/A