### PR TITLE
Posts: Change size fonts of post items and spacing

### DIFF
--- a/src/_includes/partials/components/notes-list.njk
+++ b/src/_includes/partials/components/notes-list.njk
@@ -1,7 +1,7 @@
 {% if notesListItems.length %}
   <section class="[ post-list ] [ pad-top-700 gap-bottom-900 ]">
     <div class="[ inner-wrapper ] [ sf-flow ]">
-      <h2 class="[ post-list__heading ] [ text-700 md:text-800 ]">{{ notesListHeading }}</h2>
+      <h2 class="[ post-list__heading ] [ text-600 md:text-700 ]">{{ notesListHeading }}</h2>
       <ol class="[ post-list__items ] [ sf-flow ] [ pad-top-300 ]" reversed>
         {% for item in notesListItems %}
           {% if item.date.getTime() <= global.now %}

--- a/src/_includes/partials/components/post-list.njk
+++ b/src/_includes/partials/components/post-list.njk
@@ -1,7 +1,7 @@
 {% if postListItems.length %}
   <section class="[ post-list ] [ pad-top-700 gap-bottom-900 ]">
     <div class="[ inner-wrapper ] [ sf-flow ]">
-      <h2 class="[ post-list__heading ] [ text-700 md:text-800 ]">{{ postListHeading }}</h2>
+      <h2 class="[ post-list__heading ] [ text-600 md:text-700 ]">{{ postListHeading }}</h2>
       <ol class="[ post-list__items ] [ sf-flow ] [ pad-top-300 ]" reversed>
         {% for item in postListItems %}
           {% if item.date.getTime() <= global.now %}

--- a/src/_includes/partials/components/tags-list.njk
+++ b/src/_includes/partials/components/tags-list.njk
@@ -1,7 +1,7 @@
 {% if postListItems.length %}
   <section class="[ post-list ] [ pad-top-700 gap-bottom-300 ]">
     <div class="[ inner-wrapper ] [ sf-flow ]">
-      <h3 class="[ post-list__heading ] [ text-700 md:text-800 ]">Tags</h3>
+      <h3 class="[ post-list__heading ] [ text-600 md:text-700 ]">Tags</h3>
         <p>
             {% for tag in collections.tagList %}
             <a href="/tags/{{ tag }}" class="post-list__tag">{{ tag }}</a>

--- a/src/scss/components/_post-list.scss
+++ b/src/scss/components/_post-list.scss
@@ -1,6 +1,6 @@
 .post-list {
   &__item {
-    --flow-space: #{get-size(700)};
+    --flow-space: #{get-size(500)};
   }
 
   &__link {


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Reduced space between posts' page items.

### Why

<!-- Explain why this change was made -->

Because it was too spaced for my taste

### User interface

<!-- Include screenshots before and after images-->

| Before | After |
|-|-|
| ![spaced out blog posts items](https://user-images.githubusercontent.com/11148726/116835168-40d60780-abb9-11eb-9a4c-272ef2b81f8e.png) | ![less space between the blog posts listing](https://user-images.githubusercontent.com/11148726/116835191-59462200-abb9-11eb-9cc7-630aa9ab4023.png) |

### References

<!-- Link inspiration links and references -->
- N/A