### PR TITLE
[Posts] Show external posts in list with override url

### DIFF
--- a/src/_includes/partials/components/home-post-list.njk
+++ b/src/_includes/partials/components/home-post-list.njk
@@ -9,7 +9,11 @@
               <h3 class="font-base leading-tight text-500 weight-mid">
                 {# <time datetime="{{ item.date | w3DateFilter }}">{{ item.date | dateFilter }}</time> -  #}
                 {% include "icons/arrow.svg" %}
+                {% if item.data.override_url %}
+                <a href="{{ item.data.override_url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
+                {% else %}
                 <a href="{{ item.url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
+                {% endif %}
               </h3>
             </li>
           {% endif %}

--- a/src/_includes/partials/components/post-list.njk
+++ b/src/_includes/partials/components/post-list.njk
@@ -8,7 +8,12 @@
             <li class="post-list__item">
               <h3 class="font-base leading-tight text-500 weight-mid">
                 <time datetime="{{ item.date | w3DateFilter }}">{{ item.date | dateFilter }}</time> - 
+                
+                {% if item.data.override_url %}
+                <a href="{{ item.data.override_url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
+                {% else %}
                 <a href="{{ item.url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
+                {% endif %}
               </h3>
             </li>
           {% endif %}

--- a/src/posts/steps-for-beginner-friendly-community.md
+++ b/src/posts/steps-for-beginner-friendly-community.md
@@ -2,6 +2,7 @@
 title: 3 steps for managing a beginner-friendly open source community
 date: '2021-08-20'
 override_url: https://opensource.com/article/21/8/beginner-open-source-community
+featured: true
 tags:
   - open-source
 ---

--- a/src/posts/steps-for-beginner-friendly-community.md
+++ b/src/posts/steps-for-beginner-friendly-community.md
@@ -1,0 +1,9 @@
+---
+title: 3 steps for managing a beginner-friendly open source community
+date: '2021-08-20'
+override_url: https://opensource.com/article/21/8/beginner-open-source-community
+tags:
+  - open-source
+---
+
+This post is at [https://opensource.com/article/21/8/beginner-open-source-community](https://opensource.com/article/21/8/beginner-open-source-community).


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Show external posts in list with link to override URL.
The post is listed like any other post, but when clicking it, it will lead to the post hosted somewhere else.

Fixes #87

Future improvement: an icon that hints at the fact that when clicking it takes the user to another page.

### Why

<!-- Explain why this change was made -->

This helps me be able to show my posts, even if they are posted on other platforms. Like the post I wrote for opensource.com 👉🏾  https://opensource.com/article/21/8/beginner-open-source-community

### User interface

<!-- Include screenshots before and after images-->

**Before**

list of posts with only hosted posts:
![list of posts with only hosted posts](https://user-images.githubusercontent.com/11148726/130535573-b23e25ef-9377-43f1-b225-2836580082f3.png)

**After**

list of posts with hosted posts and one external linked post:
![list of posts with new external post](https://user-images.githubusercontent.com/11148726/130535652-8d120730-4f13-4369-a466-a41bf612ddfc.png)

### References

<!-- Link inspiration links and references -->
- https://opensource.com/article/21/8/beginner-open-source-community