### PR TITLE
Posts: Shows link to cross posts for each post on footer

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -24,9 +24,10 @@
           {% include "partials/global/third-party-comments.njk" %}
         </aside>
       {% endif %}
-      {% if tags %}
+      {% if tags or crossposts %}
         <footer class="[ post__footer ] [ pad-top-500 pad-bottom-500 ]">
           <div class="inner-wrapper">
+            {% if tags %}
             <div class="[ nav ] [ box-flex align-center ]">
               <h2 class="font-base text-600 weight-mid">Filed under</h2>
               <ul class="[ nav__list ] [ box-flex align-center pad-left-400 ] [ p-category ]">
@@ -37,6 +38,24 @@
                 {% endfor %}
               </ul>
             </div>
+            {% endif %}
+            {% if crossposts %}
+            <div class="[ nav ] [ box-flex align-center ]">
+              <h2 class="font-base text-600 weight-mid">Also on</h2>
+              <ul class="[ nav__list ] [ box-flex align-center pad-left-400 ] [ p-category ]">
+                {% if crossposts.devto %}
+                  <li class="nav__item">
+                    <a href="{{ crossposts.devto }}">DEV</a>
+                  </li>
+                {% endif %}
+                {% if crossposts.medium %}
+                  <li class="nav__item">
+                    <a href="{{ crossposts.medium }}">Medium</a>
+                  </li>
+                {% endif %}
+              </ul>
+            </div>
+            {% endif %}
           </div>
         </footer>
       {% endif %}

--- a/src/posts/benefits-osh-for-our-community.md
+++ b/src/posts/benefits-osh-for-our-community.md
@@ -4,7 +4,8 @@ date: '2021-06-11'
 tags:
   - open-source
 description: In this post, I'll describe 4 benefits Open Source Hack program has for AnitaB.org Open Source community.
-medium: https://medium.com/anitab-org-open-source/how-open-source-hack-helps-our-community-and-its-projects-e035a9509a7a
+crossposts:
+  medium: https://medium.com/anitab-org-open-source/how-open-source-hack-helps-our-community-and-its-projects-e035a9509a7a
 ---
 
 At [AnitaB.org Open Source](https://github.com/anitab-org) we recently had the second version of [Open Source Hack (OSH)](https://anitab-org.github.io/events/open-source-hack/), a program, originally created by [May Winterz](https://www.linkedin.com/in/mayswinterz/).

--- a/src/posts/dataclasses-are-nice.md
+++ b/src/posts/dataclasses-are-nice.md
@@ -5,7 +5,9 @@ featured: true
 tags:
   - tech
   - python
-dev: https://community.codenewbie.org/isabelcmdcosta/dataclasses-in-python-are-nice-3e3l
+crossposts:
+  devto: https://dev.to/isabelcmdcosta/dataclasses-in-python-are-nice-1fff
+  codenewbie: https://community.codenewbie.org/isabelcmdcosta/dataclasses-in-python-are-nice-3e3l
 ---
 
 Couple weeks ago I learned about [`dataclasses`](https://docs.python.org/3/library/dataclasses.html) feature in Python. This feature is a nice way to define classes in python. This was introduced in [Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html), in particular [PEP 557](https://www.python.org/dev/peps/pep-0557/). To use this feature make sure you are running python version 3.7 or above.

--- a/src/posts/find-speaking-opportunities.md
+++ b/src/posts/find-speaking-opportunities.md
@@ -5,7 +5,8 @@ updated_at: '2021-07-05'
 tags:
   - misc
 cover_image: /images/find-speaking-opportunities.jpg
-medium: https://medium.com/codingblackfemales/how-i-find-public-speaking-opportunities-84e698df1534
+crossposts:
+  medium: https://medium.com/codingblackfemales/how-i-find-public-speaking-opportunities-84e698df1534
 ---
 
 <!--![cover image with post title, microphone and sparkles emoji](/images/find-speaking-opportunities.jpg)-->

--- a/src/posts/how-to-change-last-commit-message.md
+++ b/src/posts/how-to-change-last-commit-message.md
@@ -2,10 +2,11 @@
 title: How to change last commit message
 date: '2020-11-21'
 featured: true
+description: Often I have to change commit messages from my last commit, this is how I do it.
 tags:
   - git
-medium: https://isabelcmdcosta.medium.com/how-to-change-last-commit-message-77a7036a32c7
-description: Often I have to change commit messages from my last commit, this is how I do it.
+crossposts:
+  medium: https://isabelcmdcosta.medium.com/how-to-change-last-commit-message-77a7036a32c7
 ---
 
 Often when making changes to code, I commit them and then have to change to commit I just made, either because I think the commit message could be better or I had to make a last-minute change to the code I wish to include in the commit.

--- a/src/posts/sync-fork-with-original-with-git.md
+++ b/src/posts/sync-fork-with-original-with-git.md
@@ -5,8 +5,9 @@ description: How to sync forked repository with the original repository using gi
 tags:
   - git
   - tech
-devto: https://dev.to/isabelcmdcosta/sync-fork-with-original-repository-using-git-21ap
-meidum: https://isabelcmdcosta.medium.com/sync-fork-with-the-original-repository-using-git-24da99df916a
+crossposts:
+  devto: https://dev.to/isabelcmdcosta/sync-fork-with-original-repository-using-git-21ap
+  medium: https://isabelcmdcosta.medium.com/sync-fork-with-the-original-repository-using-git-24da99df916a
 ---
 
 When you want to contribute to an open source repository, you usually [fork a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) so you can do your changes and later submit them via a pull request. After forking the repository on GitHub, and cloning it into your local environment - `git clone <forked repository url>` - the repository will have a remote URL setup, usually named `origin`.


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
Show links to cross posts on footer of each blog post. For example, if I have a post on dev.to, medium or both these links will show on bottom.

Fixes #12

### Why

<!-- Explain why this change was made -->

- I want to cross-reference everything.
- So I can easily get the links to cross-posts in multiple platforms from my website.
- If people use the mentioned blogging platforms they can comment, reference, save and like in those platforms.

### User interface

<!-- Include screenshots before and after images-->

| Before | After |
|-|-|
| ![only tags show on footer](https://user-images.githubusercontent.com/11148726/132094818-5c9f2960-6f60-4abb-98a9-04c98b1ae1ca.png) | ![tags and crossposts links show on footer](https://user-images.githubusercontent.com/11148726/132094811-7fe569c9-3679-43d5-84e7-f0da9f08ff77.png) |

### References

<!-- Link inspiration links and references -->
N/A