### PR TITLE
Add talks and posts to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ I added a couple additional options to the posts frontmatter. Here's some:
 - https://gohugo.io/getting-started/quick-start/
 - https://github.com/LukasJoswiak/etch/wiki/Getting-started
 - git submodules: https://git-scm.com/book/en/v2/Git-Tools-Submodules
+- https://markdowntohtml.com/

--- a/content/posts/dataclasses-are-nice.md
+++ b/content/posts/dataclasses-are-nice.md
@@ -1,7 +1,6 @@
 ---
 title: Dataclasses in Python are nice!
 date: '2021-03-13'
-featured: true
 tags:
   - tech
   - python

--- a/content/posts/ficheiros-base-num-projeto-open-source.md
+++ b/content/posts/ficheiros-base-num-projeto-open-source.md
@@ -1,7 +1,6 @@
 ---
 title: Ficheiros base num projeto Open Source
 date: '2020-11-07'
-featured: true
 tags:
   - portugues
   - open-source

--- a/content/posts/find-speaking-opportunities.md
+++ b/content/posts/find-speaking-opportunities.md
@@ -1,6 +1,7 @@
 ---
 title: How I find Public Speaking Opportunities
 date: '2021-06-10'
+featured: true
 updated_at: '2021-07-05'
 tags:
   - misc

--- a/content/posts/how-to-change-last-commit-message.md
+++ b/content/posts/how-to-change-last-commit-message.md
@@ -1,7 +1,6 @@
 ---
 title: How to change last commit message
 date: '2020-11-21'
-featured: true
 description: Often I have to change commit messages from my last commit, this is how I do it.
 tags:
   - git

--- a/content/posts/participation-google-open-source-programs.md
+++ b/content/posts/participation-google-open-source-programs.md
@@ -1,6 +1,7 @@
 ---
 title: I’ve been a contributor, mentor, and admin in Google Open Source programs
 date: '2022-06-09'
+featured: true
 description: This is my experience as GSoC 2018 student, GCI 2019 mentor and GSoC 2020 admin.
 tags:
   - open-source

--- a/content/posts/participation-google-open-source-programs.md
+++ b/content/posts/participation-google-open-source-programs.md
@@ -1,7 +1,6 @@
 ---
 title: I’ve been a contributor, mentor, and admin in Google Open Source programs
 date: '2022-06-09'
-featured: true
 description: This is my experience as GSoC 2018 student, GCI 2019 mentor and GSoC 2020 admin.
 tags:
   - open-source

--- a/content/posts/setup-tinyproxy-as-forward-and-reverse-proxy.md
+++ b/content/posts/setup-tinyproxy-as-forward-and-reverse-proxy.md
@@ -1,7 +1,6 @@
 ---
 title: How I set up Tinyproxy as a forward proxy and reverse proxy
 date: '2018-09-06'
-featured: true
 tags:
   - tech
 crossposts:

--- a/content/posts/steps-for-beginner-friendly-community.md
+++ b/content/posts/steps-for-beginner-friendly-community.md
@@ -2,7 +2,6 @@
 title: 3 steps for managing a beginner-friendly open source community 🔗
 date: '2021-08-20'
 override_url: https://opensource.com/article/21/8/beginner-open-source-community
-featured: true
 tags:
   - open-source
 ---

--- a/content/posts/sync-fork-with-original-with-git.md
+++ b/content/posts/sync-fork-with-original-with-git.md
@@ -2,7 +2,6 @@
 title: Sync fork with the original repository using git
 date: '2021-09-04'
 description: How to sync forked repository with the original repository using git on the terminal
-featured: true
 tags:
   - git
   - tech

--- a/content/posts/tools-i-use-for-my-masters-thesis.md
+++ b/content/posts/tools-i-use-for-my-masters-thesis.md
@@ -1,7 +1,6 @@
 ---
 title: Tools I use for my Master’s thesis
 date: '2018-01-16'
-featured: true
 tags:
     - misc
 crossposts:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,6 @@
 {{ define "main" }}
 {{ .Content }}
 {{- partial "social-media-links.html" . -}}
-<br>
 {{- partial "featured-posts.html" . -}}
 {{- partial "featured-talks.html" . -}}
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
 {{ .Content }}
 {{- partial "social-media-links.html" . -}}
+<br>
+{{- partial "featured-posts.html" . -}}
+<!-- {{- partial "featured-talks.html" . -}} -->
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,5 +3,5 @@
 {{- partial "social-media-links.html" . -}}
 <br>
 {{- partial "featured-posts.html" . -}}
-<!-- {{- partial "featured-talks.html" . -}} -->
+{{- partial "featured-talks.html" . -}}
 {{ end }}

--- a/layouts/partials/featured-posts.html
+++ b/layouts/partials/featured-posts.html
@@ -4,6 +4,7 @@
 {{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
     {{ if .Params.featured }}
         {{ .Render "li" }}
+        <!-- {{- partial "li_note.html" . -}} -->
     {{ end }}
 {{- end }}
 </ul>

--- a/layouts/partials/featured-posts.html
+++ b/layouts/partials/featured-posts.html
@@ -1,4 +1,4 @@
-<h3>📝 posts</h3>
+<h3>► posts</h3>
 <br>
 <ul id="posts">
 {{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
@@ -8,3 +8,5 @@
     {{ end }}
 {{- end }}
 </ul>
+
+<p>Check out <a href="/posts">all posts</a></p>

--- a/layouts/partials/featured-posts.html
+++ b/layouts/partials/featured-posts.html
@@ -1,4 +1,4 @@
-<h3>posts</h3>
+<h3>📝 posts</h3>
 <br>
 <ul id="posts">
 {{- range where site.RegularPages "Type" "in" site.Params.mainSections }}

--- a/layouts/partials/featured-posts.html
+++ b/layouts/partials/featured-posts.html
@@ -1,0 +1,9 @@
+<h3>posts</h3>
+<br>
+<ul id="posts">
+{{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
+    {{ if .Params.featured }}
+        {{ .Render "li" }}
+    {{ end }}
+{{- end }}
+</ul>

--- a/layouts/partials/featured-talks.html
+++ b/layouts/partials/featured-talks.html
@@ -1,0 +1,7 @@
+<h3>featured talks</h3>
+<br>
+<ul id="posts">
+{{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
+    {{ .Render "li" }}
+{{- end }}
+</ul>

--- a/layouts/partials/featured-talks.html
+++ b/layouts/partials/featured-talks.html
@@ -1,4 +1,4 @@
-<h3>featured talks</h3>
+<h3>🎙️ talks</h3>
 <br>
 <ul id="posts">
     <li>How to Get into Open Source @ <a href="https://www.meetup.com/Women-Who-Code-London">Women Who Code London</a> • <a href="https://www.youtube.com/watch?v=0buL1lnqUz0">Video</a></li>

--- a/layouts/partials/featured-talks.html
+++ b/layouts/partials/featured-talks.html
@@ -1,7 +1,8 @@
 <h3>featured talks</h3>
 <br>
 <ul id="posts">
-{{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
-    {{ .Render "li" }}
-{{- end }}
+    <li>How to Get into Open Source @ <a href="https://www.meetup.com/Women-Who-Code-London">Women Who Code London</a> • <a href="https://www.youtube.com/watch?v=0buL1lnqUz0">Video</a></li>
+    <li>Contribuir para Open Source como colaborador e maintainer @ <a href="https://devfest.gdgportugal.xyz/">Devfest Portugal</a> • <a href="https://youtu.be/-EFVDjDdeXw?t=6766">Video</a> 🇵🇹</li>
+    <li>How documentation and open communication leads to better collaboration @ <a href="https://www.meetup.com/Ladies-of-Code-UK/events/272472641/">Ladies of Code London</a> • <a href="https://youtu.be/KGG3PXYwKIE?t=1491">Video</a></li>
 </ul>
+        

--- a/layouts/partials/featured-talks.html
+++ b/layouts/partials/featured-talks.html
@@ -1,4 +1,4 @@
-<h3>🎙️ talks</h3>
+<h3>► talks</h3>
 <br>
 <ul id="posts">
     <li>How to Get into Open Source @ <a href="https://www.meetup.com/Women-Who-Code-London">Women Who Code London</a> • <a href="https://www.youtube.com/watch?v=0buL1lnqUz0">Video</a></li>
@@ -6,3 +6,4 @@
     <li>How documentation and open communication leads to better collaboration @ <a href="https://www.meetup.com/Ladies-of-Code-UK/events/272472641/">Ladies of Code London</a> • <a href="https://youtu.be/KGG3PXYwKIE?t=1491">Video</a></li>
 </ul>
         
+<p>Check out <a href="/talks">all talks</a></p>

--- a/layouts/partials/social-media-links.html
+++ b/layouts/partials/social-media-links.html
@@ -1,7 +1,7 @@
 <p>
-    <a href="{{.Site.Params.socialMedia.github}}">GitHub</a> |
-    <a href="{{.Site.Params.socialMedia.linkedin}}">LinkedIn</a> |
-    <a href="{{.Site.Params.socialMedia.twitter}}">Twitter</a> |
-    <a href="{{.Site.Params.socialMedia.medium}}">Medium</a> |
+    <a href="{{.Site.Params.socialMedia.github}}">GitHub</a> •
+    <a href="{{.Site.Params.socialMedia.linkedin}}">LinkedIn</a> •
+    <a href="{{.Site.Params.socialMedia.twitter}}">Twitter</a> •
+    <a href="{{.Site.Params.socialMedia.medium}}">Medium</a> •
     <a href="{{.Site.Params.socialMedia.devto}}">DEV</a>
 </p>


### PR DESCRIPTION
### What

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Add a list of featured posts and talks on homepage.
Updated the posts I consider should be listed as featured.

#TODO later: the font size is different than the little bio. I should revisit this later.

### Why

<!-- Explain why this change was made -->
I want to highlight my community work on the homepage, in case a visitor does not check the talks or posts page. This will give a good overview of my contributions to the community at first sight.

### User interface

<!-- Include screenshots before and after images-->

| Before | After |
|-|-|
| <img width="660" alt="image" src="https://user-images.githubusercontent.com/11148726/178117137-2c1f4326-7fdb-4710-b5ca-3e5fd42e15c8.png"> | <img width="737" alt="image" src="https://user-images.githubusercontent.com/11148726/178117140-43a7fa7d-d9e9-412b-8f55-999a19f010dd.png"> |

### References

<!-- Link inspiration links and references -->
This is how it looked before: https://isabelcosta.github.io/fourth-personal-website/
